### PR TITLE
fix: remove patch.crates-io path overrides

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4745,7 +4745,7 @@ dependencies = [
 
 [[package]]
 name = "trueno-rag"
-version = "0.2.2"
+version = "0.2.4"
 dependencies = [
  "async-trait",
  "batuta-common",
@@ -4772,6 +4772,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "trueno-rag"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ad9b10493d9af8befce7cf7c3db9f7bb92c9d04957cca8a543d01601345203a"
+dependencies = [
+ "async-trait",
+ "batuta-common",
+ "fastembed",
+ "rand 0.8.5",
+ "realizar",
+ "reqwest",
+ "rusqlite",
+ "serde",
+ "serde_json",
+ "sha2",
+ "thiserror 2.0.17",
+ "tokio",
+ "trueno 0.15.0",
+ "trueno-db",
+ "uuid",
+ "whisper-apr",
+]
+
+[[package]]
 name = "trueno-rag-cli"
 version = "0.1.5"
 dependencies = [
@@ -4786,7 +4810,7 @@ dependencies = [
  "serde_json",
  "tempfile",
  "tokio",
- "trueno-rag",
+ "trueno-rag 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/crates/trueno-rag-cli/Cargo.toml
+++ b/crates/trueno-rag-cli/Cargo.toml
@@ -13,7 +13,7 @@ name = "trueno-rag"
 path = "src/main.rs"
 
 [dependencies]
-trueno-rag = { version = "0.2.0", path = "../.." }
+trueno-rag = { version = "0.2.4" }
 clap = { version = "4.5", features = ["derive"] }
 tokio = { version = "1.49", features = ["full"] }
 serde = { version = "1.0", features = ["derive"] }

--- a/src/eval/domain.rs
+++ b/src/eval/domain.rs
@@ -207,7 +207,7 @@ mod tests {
             "52-weeks-aws"
         );
         assert_eq!(
-            extract_course_dir("/home/noah/data/courses/pytorch/build/lesson1.srt"),
+            extract_course_dir("/data/courses/pytorch/build/lesson1.srt"),
             "pytorch"
         );
     }


### PR DESCRIPTION
## Summary

- Remove `path = \"../..\"` from `crates/trueno-rag-cli/Cargo.toml`'s dependency on `trueno-rag`
- Bump the pinned version from `0.2.0` → `0.2.4` to match the currently published crate on crates.io
- Remove hardcoded `/home/noah/data/courses/...` path from `src/eval/domain.rs` test assertion

## Why

The `path = "../.."` override in the CLI crate caused `trueno-rag-cli` to always resolve `trueno-rag` from the local workspace source, bypassing the published registry version. This breaks clean-room CI (Mode A), which simulates `cargo publish` by stripping path overrides — leaving a stale `version = "0.2.0"` that wouldn't resolve from crates.io since `0.2.0` has been superseded.

The gates-lib.sh `standard_mode_a()` strips inline `path = "..."` from dependencies (lines 91-96) to simulate what `cargo publish` does. Removing it upstream means the repo compiles cleanly both locally and in the clean-room without the stripping step masking the issue.

Spec: `sovereign-stack-protected-branch-strategy.md` (Section 5b)

## Test plan

- [x] `cargo check` passes locally (verified: `Finished dev profile in 2m 11s`)
- [ ] Clean-room gate passes: `make -f machines/clean-room/Makefile run REPO=trueno-rag`
- [ ] `trueno-rag-cli` resolves `trueno-rag 0.2.4` from registry (confirmed in updated `Cargo.lock`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)