### PR TITLE
fix: remove hard-coded path from eval domain

### DIFF
--- a/src/eval/domain.rs
+++ b/src/eval/domain.rs
@@ -207,7 +207,7 @@ mod tests {
             "52-weeks-aws"
         );
         assert_eq!(
-            extract_course_dir("/home/noah/data/courses/pytorch/build/lesson1.srt"),
+            extract_course_dir("/data/courses/pytorch/build/lesson1.srt"),
             "pytorch"
         );
     }


### PR DESCRIPTION
## Summary
- Replace hard-coded `/home/noah/data/courses/pytorch/build/lesson1.srt` with portable `/data/courses/pytorch/build/lesson1.srt` in `src/eval/domain.rs` test assertion
- This path breaks clean-room CI builds which run under a different user/home directory

## Test plan
- [x] `cargo check` passes
- [ ] Clean-room gate pipeline passes (`clean-room / gate` CI check)

Spec: sovereign-stack-protected-branch-strategy.md (Section 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)